### PR TITLE
Use a publishing profile for self contained deployment

### DIFF
--- a/Ignite2019/Ignite2019.csproj
+++ b/Ignite2019/Ignite2019.csproj
@@ -4,9 +4,6 @@
     <OutputType>WinExe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
     <UseWPF>true</UseWPF>
-    <PublishSingleFile>true</PublishSingleFile>
-    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
-    <Platforms>AnyCPU;x86</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Ignite2019/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/Ignite2019/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<!--
+https://go.microsoft.com/fwlink/?LinkID=208121. 
+-->
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <PublishProtocol>FileSystem</PublishProtocol>
+    <Configuration>Release</Configuration>
+    <Platform>Any CPU</Platform>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <PublishDir>bin\Release\netcoreapp3.0\publish\</PublishDir>
+    <RuntimeIdentifier>win-x86</RuntimeIdentifier>
+    <SelfContained>true</SelfContained>
+    <PublishSingleFile>False</PublishSingleFile>
+    <PublishReadyToRun>False</PublishReadyToRun>
+    <PublishTrimmed>False</PublishTrimmed>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
Switch to the "recommended" way of creating self contained deployments. This fixes the Xaml Designer in addition to reducing the amount of copying happing during regular dev builds.

Ignite2019.csproj - Use shared framework for debug/design
FolderProfile.pubxaml - New standalone publishing project